### PR TITLE
Password reset and Super Admin features like changing passwords and user roles

### DIFF
--- a/src/components/super-admin-dashboard/UserManagement.tsx
+++ b/src/components/super-admin-dashboard/UserManagement.tsx
@@ -173,7 +173,7 @@ const UserManagement: React.FC = () => {
       missingRequirementsMessage += '\n • One Special Character';
     }
 
-    if (missingRequirementsMessage == 'The New Password must contain:') {
+    if (missingRequirementsMessage === 'The New Password must contain:') {
       //Password has all requirements fullfilled
       return null;
     } else {

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -14,7 +14,11 @@ import {
   Collapse,
   Paper,
 } from '@mui/material';
-import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import {
+  GoogleAuthProvider,
+  sendPasswordResetEmail,
+  signInWithPopup,
+} from 'firebase/auth';
 import { auth } from '../firebase';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { XCircle } from 'lucide-react';
@@ -52,6 +56,8 @@ const AuthPage: React.FC = () => {
   const [showPasswordRequirements, setShowPasswordRequirements] =
     useState(false);
   const { signIn, signUp } = useAuth();
+
+  const emailRegExpression = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; //email format
 
   const [passwordRequirements, setPasswordRequirements] = useState({
     length: false,
@@ -136,6 +142,18 @@ const AuthPage: React.FC = () => {
 
   const handlePasswordBlur = () => {
     setShowPasswordRequirements(false);
+  };
+
+  const handleForgotPassword = async () => {
+    //Uses Firestore's build in function to email user with reset link
+    sendPasswordResetEmail(auth, email)
+      .then(() => {
+        alert('A Password Reset Link has been sent to your email');
+      })
+      .catch((error) => {
+        console.log(error.code);
+        console.log(error.message);
+      });
   };
 
   return (
@@ -240,6 +258,18 @@ const AuthPage: React.FC = () => {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                 />
+                {emailRegExpression.test(email) && ( //reset password only appears if email is correctly formatted
+                  <Box>
+                    <Tabs
+                      onChange={handleForgotPassword}
+                      centered
+                      style={{ height: 5, margin: -10 }}
+                    >
+                      <Tab label="Forget Password?" />
+                    </Tabs>
+                  </Box>
+                )}
+
                 <Button
                   fullWidth
                   variant="contained"

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -120,4 +120,20 @@ export const usersService = {
   async getActiveUsersByRole(role: UserRole): Promise<User[]> {
     return this.getUsersByRoleAndStatus(role, 'active');
   },
+
+  async changeUserRole(userId: string, newRole: any) {
+    try {
+      // Reference the specific document using its ID
+      const userDocRef = doc(db, 'users', userId);
+
+      //Update the userType field
+      await updateDoc(userDocRef, {
+        userType: newRole,
+      });
+
+      console.log('User role updated successfully');
+    } catch (error) {
+      console.error('Error updating user role:', error);
+    }
+  },
 };


### PR DESCRIPTION
## Description

Password reset when logging and Super Admin features like changing passwords and user roles. A Super Admin has the abaility to change a user's password. In the dialog window, I added alert messages that inform the user if the password meets our standards or if they need to add things like at least one number. The Super Admin can now also change roles. If they try to make someone a super admin, we give them a warning. I super admin can not change their own role ensuring there at least remains one super admin at all times

## Related Issue

[Link to the related issue, if applicable]

Locally Tested

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

[Describe the tests you ran]

## Checklist:

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
